### PR TITLE
Update FAQ: add new V2 fee structure 

### DIFF
--- a/faq.md
+++ b/faq.md
@@ -119,9 +119,9 @@ According to YIPs [51](https://yips.yearn.finance/YIPS/yip-51), [52](https://yip
 - **0% fee** on any funds withdrawn from any V2 vault.
 - **2% annualized management fee** that goes to the treasury (accrued per block, collected on each harvest).
 - **20% fee** on additinal yield
-  -Half (10%) goes to the treasury.
-    -from the 10% going to the treasury, 5% goes to the operation fund and 5% to YFI stakers ([YIP-54](https://yips.yearn.finance/YIPS/yip-54)).
-  -Half (10%) goes to the strategist as reward.
+  - Half (10%) goes to the treasury.
+    - from the 10% going to the treasury, 5% goes to the operation fund and 5% to YFI stakers ([YIP-54](https://yips.yearn.finance/YIPS/yip-54)).
+  - Half (10%) goes to the strategist as reward.
   
 #### Can you explain the 5% fee on additional yield?
 

--- a/faq.md
+++ b/faq.md
@@ -108,14 +108,14 @@ But if you think something can be improved, or you found a bug, we want to squas
 
 #### What are the Fees?
 
-For V1 vaults, the fee structute is the following:
+For V1 vaults, the fee structure is the following:
 - **0.5% fee** on funds withdrawn from active strategies
   - Each vault has some amount of the total funds idle and most of them active in the strategy. The idle funds are the difference between `vault holdings` and `strategy holdings`, you can see them on [feel the Yearn](https://feel-the-Yearn.app/).
   - When you withdraw, if your funds come from the idle funds, you won't be charged any withdrawal fee. If they come from the strategy, you will be charged the 0.5% fee.
 - **5% fee** on additional yield
   - For community-made strategies, like the new yETH vault, currently 10% of this fee goes to the strategy creator. The other 90% goes to the treasury and is then distributed to governance.
 
-According to YIPs [51](https://yips.yearn.finance/YIPS/yip-51), [52](https://yips.yearn.finance/YIPS/yip-52) and [54](https://yips.yearn.finance/YIPS/yip-54) the fee struture of V2 vaults is the following:
+According to YIPs [51](https://yips.yearn.finance/YIPS/yip-51), [52](https://yips.yearn.finance/YIPS/yip-52) and [54](https://yips.yearn.finance/YIPS/yip-54) the fee structure of V2 vaults is the following:
 - **0% fee** on any funds withdrawn from any V2 vault.
 - **2% annualized management fee** that goes to the treasury (accrued per block, collected on each harvest and applied on all the funds managed by the strategy).
 - **20% performance fee** collected and distributed on each harvest call (only if the strategy reports gains)

--- a/faq.md
+++ b/faq.md
@@ -120,7 +120,7 @@ According to YIPs [51](https://yips.yearn.finance/YIPS/yip-51), [52](https://yip
 - **2% annualized management fee** that goes to the treasury (accrued per block, collected on each harvest and applied on all the funds managed by the strategy).
 - **20% performance fee** collected and distributed on each harvest call (only if the strategy reports gains)
   - Half (10%) goes to the treasury.
-    - from the 10% going to the treasury, 5% goes to the operation fund and 5% to YFI stakers according to [YIP-54](https://yips.yearn.finance/YIPS/yip-54). The most recent      governance votation [YIP-56](https://gov.yearn.finance/t/yip-56-buyback-and-build/8929) a.k.a B.A.B.Y eliminated the 5% going to YFI stakers and implemented buybacks of YFI with the fees collectedby the treasury.
+    - from the 10% going to the treasury, 5% goes to the operation fund and 5% to YFI stakers according to [YIP-54](https://yips.yearn.finance/YIPS/yip-54). The most recent governance votation [YIP-56](https://gov.yearn.finance/t/yip-56-buyback-and-build/8929) a.k.a B.A.B.Y eliminated the 5% going to YFI stakers and implemented buybacks of YFI with the fees collectedby the treasury.
     
   - Half (10%) goes to the strategist as reward.
   

--- a/faq.md
+++ b/faq.md
@@ -107,13 +107,20 @@ But if you think something can be improved, or you found a bug, we want to squas
 - You will get the amount you originally put in, plus the yield you've earned, minus the fees.
 
 #### What are the Fees?
-
+- For V1 vaults, the fee structute is the following:
 - **0.5% fee** on funds withdrawn from active strategies
   - Each vault has some amount of the total funds idle and most of them active in the strategy. The idle funds are the difference between `vault holdings` and `strategy holdings`, you can see them on [feel the Yearn](https://feel-the-Yearn.app/).
   - When you withdraw, if your funds come from the idle funds, you won't be charged any withdrawal fee. If they come from the strategy, you will be charged the 0.5% fee.
 - **5% fee** on additional yield
   - For community-made strategies, like the new yETH vault, currently 10% of this fee goes to the strategy creator. The other 90% goes to the treasury and is then distributed to governance.
-
+- According to YIPs 51, 52 and 54 the fee struture of V2 vaults is the following:
+- **0% fee** on any funds withdrawn from any V2 vault.
+- **2% annualized management fee** that goes to the treasury (accrued per block, collected on each harvest).
+- **20% fee** on additinal yield
+  -Half (10%) goes to the treasury.
+    -from the 10% going to the treasury, 5% goes to the operation fund and 5% to YFI stakers (YIP-54).
+  -Half (10%) goes to the strategist as reward.
+  
 #### Can you explain the 5% fee on additional yield?
 
 - Formerly this was called a "5% fee on subsidized gas" which confused literally everyone except Andre. Technically it is not a performance fee — it's a fee on the some profit-generating transactions that incur high gas costs and are critical to the vault's internal functioning.

--- a/faq.md
+++ b/faq.md
@@ -108,20 +108,20 @@ But if you think something can be improved, or you found a bug, we want to squas
 
 #### What are the Fees?
 
-Vault Version | Management Fee | Performance Fee | Withdrawal Fee|
----|---|---|---|
-v1 | N/A | 5% | 0.5% |
-v2 | 2% | 20% | N/A |
+| Vault Version | Management Fee | Performance Fee | Withdrawal Fee |
+| ------------- | -------------- | --------------- | -------------- |
+| v1            | N/A            | 5%              | 0.5%           |
+| v2            | 2%             | 20%             | N/A            |
 
 **Notes:**
 
 - **Withdrawal Fee** only applies on funds withdrawn from active Strategies.
-   - Each vault has some amount of the total funds idle and most of them active in the Strategy.
-   - Idle funds is the difference between `vault holdings` and `strategy holdings`, and can be seen on [feel the Yearn](https://feel-the-Yearn.app/).
+  - Each vault has some amount of the total funds idle and most of them active in the Strategy.
+  - Idle funds is the difference between `vault holdings` and `strategy holdings`, and can be seen on [feel the Yearn](https://feel-the-Yearn.app/).
   - When there is a withdrawal, if idle funds can cover the full amount, there will not be a withdrawal fee applied. If funds will need to be pulled from the Strategy in order to cover the withdrawal request, the Withdrawal Fee is applied.
 - **Performance Fee** is only applied on the performance gains.
-   - For v1 vaults, the proceeds from this fee is split between Treasury and Strategist 90:10. 
-   - For v2 vaults, the split between Treasury and Strategist is 50:50.
+  - For v1 vaults, the proceeds from this fee is split between Treasury and Strategist 90:10.
+  - For v2 vaults, the split between Treasury and Strategist is 50:50.
 - **Management Fee** is annualized and assigned to Treasury. It accrues per block, is collected on each harvest and is applied on the total of the funds managed by the Strategy.
 - **Further reading**, see [YIP-51](https://yips.yearn.finance/YIPS/yip-51), [YIP-52](https://yips.yearn.finance/YIPS/yip-52), [YIP-54](https://yips.yearn.finance/YIPS/yip-54), and [YIP-56](https://gov.yearn.finance/t/yip-56-buyback-and-build/8929).
 

--- a/faq.md
+++ b/faq.md
@@ -125,30 +125,6 @@ But if you think something can be improved, or you found a bug, we want to squas
 - **Management Fee** is annualized and assigned to Treasury. It accrues per block, is collected on each harvest and is applied on the total of the funds managed by the Strategy.
 - **Further reading**, see [YIP-51](https://yips.yearn.finance/YIPS/yip-51), [YIP-52](https://yips.yearn.finance/YIPS/yip-52), [YIP-54](https://yips.yearn.finance/YIPS/yip-54), and [YIP-56](https://gov.yearn.finance/t/yip-56-buyback-and-build/8929).
 
-#### Can you explain the 5% fee on additional yield?
-
-- Formerly this was called a "5% fee on subsidized gas" which confused literally everyone except Andre. Technically it is not a performance fee — it's a fee on the some profit-generating transactions that incur high gas costs and are critical to the vault's internal functioning.
-- Each vault has multiple levels. Here are two examples that show where this fee is taken when the `harvest()` function is called.
-- yCRV Vault example:
-  - Level 1: stablecoins earn interest in money markets \(compound, aave, dydx\)
-  - Level 2: the level 1 tokens \(yDAI, yUSDC, yUSDT, and yTUSD\) are provided as liquidty to the yCRV pool to earn trading fees
-  - Level 3: the strategy earns CRV token rewards which it recycles into yCRV—**this is the only level where the 5% fee is taken.**
-- USDC Vault example:
-  - Level 1: Interest for being lent out at Compound
-  - Level 2: COMP liquidated to USDC
-  - Level 3: The strategy earns DF tokens rewards from DForce that get harvested and sold for USDC—**this is the only level where the 5% fee is taken.**
-
-#### Where do the fees go?
-
-- They go to a dedicated treasury [contract](https://etherscan.io/address/0x93A62dA5a14C80f265DAbC077fCEE437B1a0Efde).
-- From the treasury they stay up to the \$500k limit, over that amount they are redirected to the governance staking [contract](https://etherscan.io/address/0xBa37B002AbaFDd8E89a1995dA52740bbC013D992).
-
-#### Did the fees always go there?
-
-- No, when Yearn started they went directly to Andre's [address](https://etherscan.io/address/0x2d407ddb06311396fe14d4b49da5f0471447d45c).
-- Then we handed off to the [multisig](https://etherscan.io/address/0xFEB4acf3df3cDEA7399794D0869ef76A6EfAff52) and fees went directly there.
-- And before our current gov v2, staking rewards went [here](https://etherscan.io/address/0xb01419E74D8a2abb1bbAD82925b19c36C191A701)
-
 #### Yield
 
 - We plan to make a dashboard in the future that will clearly show your current APY of all the positions you have open. Currently for the Vaults as they are still in beta we are not showing the APY live, but it is post on [twitter](https://twitter.com/iearnfinance) around once a day. You can roughly estimate the yield you are getting by looking at what the [current strategy](https://feel-the-Yearn.vercel.app/) is farming and checking what its APY is.

--- a/faq.md
+++ b/faq.md
@@ -120,7 +120,8 @@ According to YIPs [51](https://yips.yearn.finance/YIPS/yip-51), [52](https://yip
 - **2% annualized management fee** that goes to the treasury (accrued per block, collected on each harvest and applied on all the funds managed by the strategy).
 - **20% performance fee** collected and distributed on each harvest call (only if the strategy reports gains)
   - Half (10%) goes to the treasury.
-    - from the 10% going to the treasury, 5% goes to the operation fund and 5% to YFI stakers ([YIP-54](https://yips.yearn.finance/YIPS/yip-54)).
+    - from the 10% going to the treasury, 5% goes to the operation fund and 5% to YFI stakers according to [YIP-54](https://yips.yearn.finance/YIPS/yip-54). The most recent      governance votation [YIP-56](https://gov.yearn.finance/t/yip-56-buyback-and-build/8929) a.k.a B.A.B.Y eliminated the 5% going to YFI stakers and implemented buybacks of YFI with the fees collectedby the treasury.
+    
   - Half (10%) goes to the strategist as reward.
   
 #### Can you explain the 5% fee on additional yield?

--- a/faq.md
+++ b/faq.md
@@ -117,8 +117,8 @@ For V1 vaults, the fee structute is the following:
 
 According to YIPs [51](https://yips.yearn.finance/YIPS/yip-51), [52](https://yips.yearn.finance/YIPS/yip-52) and [54](https://yips.yearn.finance/YIPS/yip-54) the fee struture of V2 vaults is the following:
 - **0% fee** on any funds withdrawn from any V2 vault.
-- **2% annualized management fee** that goes to the treasury (accrued per block, collected on each harvest).
-- **20% fee** on additinal yield
+- **2% annualized management fee** that goes to the treasury (accrued per block, collected on each harvest and applied on all the funds managed by the strategy).
+- **20% performance fee** collected and distributed on each harvest call (only if the strategy reports gains)
   - Half (10%) goes to the treasury.
     - from the 10% going to the treasury, 5% goes to the operation fund and 5% to YFI stakers ([YIP-54](https://yips.yearn.finance/YIPS/yip-54)).
   - Half (10%) goes to the strategist as reward.

--- a/faq.md
+++ b/faq.md
@@ -107,18 +107,20 @@ But if you think something can be improved, or you found a bug, we want to squas
 - You will get the amount you originally put in, plus the yield you've earned, minus the fees.
 
 #### What are the Fees?
-- For V1 vaults, the fee structute is the following:
+
+For V1 vaults, the fee structute is the following:
 - **0.5% fee** on funds withdrawn from active strategies
   - Each vault has some amount of the total funds idle and most of them active in the strategy. The idle funds are the difference between `vault holdings` and `strategy holdings`, you can see them on [feel the Yearn](https://feel-the-Yearn.app/).
   - When you withdraw, if your funds come from the idle funds, you won't be charged any withdrawal fee. If they come from the strategy, you will be charged the 0.5% fee.
 - **5% fee** on additional yield
   - For community-made strategies, like the new yETH vault, currently 10% of this fee goes to the strategy creator. The other 90% goes to the treasury and is then distributed to governance.
-- According to YIPs 51, 52 and 54 the fee struture of V2 vaults is the following:
+
+According to YIPs [51](https://yips.yearn.finance/YIPS/yip-51), [52](https://yips.yearn.finance/YIPS/yip-52) and [54](https://yips.yearn.finance/YIPS/yip-54) the fee struture of V2 vaults is the following:
 - **0% fee** on any funds withdrawn from any V2 vault.
 - **2% annualized management fee** that goes to the treasury (accrued per block, collected on each harvest).
 - **20% fee** on additinal yield
   -Half (10%) goes to the treasury.
-    -from the 10% going to the treasury, 5% goes to the operation fund and 5% to YFI stakers (YIP-54).
+    -from the 10% going to the treasury, 5% goes to the operation fund and 5% to YFI stakers ([YIP-54](https://yips.yearn.finance/YIPS/yip-54)).
   -Half (10%) goes to the strategist as reward.
   
 #### Can you explain the 5% fee on additional yield?

--- a/faq.md
+++ b/faq.md
@@ -108,22 +108,23 @@ But if you think something can be improved, or you found a bug, we want to squas
 
 #### What are the Fees?
 
-For V1 vaults, the fee structure is the following:
-- **0.5% fee** on funds withdrawn from active strategies
-  - Each vault has some amount of the total funds idle and most of them active in the strategy. The idle funds are the difference between `vault holdings` and `strategy holdings`, you can see them on [feel the Yearn](https://feel-the-Yearn.app/).
-  - When you withdraw, if your funds come from the idle funds, you won't be charged any withdrawal fee. If they come from the strategy, you will be charged the 0.5% fee.
-- **5% fee** on additional yield
-  - For community-made strategies, like the new yETH vault, currently 10% of this fee goes to the strategy creator. The other 90% goes to the treasury and is then distributed to governance.
+Vault Version | Management Fee | Performance Fee | Withdrawal Fee|
+---|---|---|---|
+v1 | N/A | 5% | 0.5% |
+v2 | 2% | 20% | N/A |
 
-According to YIPs [51](https://yips.yearn.finance/YIPS/yip-51), [52](https://yips.yearn.finance/YIPS/yip-52) and [54](https://yips.yearn.finance/YIPS/yip-54) the fee structure of V2 vaults is the following:
-- **0% fee** on any funds withdrawn from any V2 vault.
-- **2% annualized management fee** that goes to the treasury (accrued per block, collected on each harvest and applied on all the funds managed by the strategy).
-- **20% performance fee** collected and distributed on each harvest call (only if the strategy reports gains)
-  - Half (10%) goes to the treasury.
-    - from the 10% going to the treasury, 5% goes to the operation fund and 5% to YFI stakers according to [YIP-54](https://yips.yearn.finance/YIPS/yip-54). The most recent governance votation [YIP-56](https://gov.yearn.finance/t/yip-56-buyback-and-build/8929) a.k.a B.A.B.Y eliminated the 5% going to YFI stakers and implemented buybacks of YFI with the fees collectedby the treasury.
-    
-  - Half (10%) goes to the strategist as reward.
-  
+**Notes:**
+
+- **Withdrawal Fee** only applies on funds withdrawn from active Strategies.
+   - Each vault has some amount of the total funds idle and most of them active in the Strategy.
+   - Idle funds is the difference between `vault holdings` and `strategy holdings`, and can be seen on [feel the Yearn](https://feel-the-Yearn.app/).
+  - When there is a withdrawal, if idle funds can cover the full amount, there will not be a withdrawal fee applied. If funds will need to be pulled from the Strategy in order to cover the withdrawal request, the Withdrawal Fee is applied.
+- **Performance Fee** is only applied on the performance gains.
+   - For v1 vaults, the proceeds from this fee is split between Treasury and Strategist 90:10. 
+   - For v2 vaults, the split between Treasury and Strategist is 50:50.
+- **Management Fee** is annualized and assigned to Treasury. It accrues per block, is collected on each harvest and is applied on the total of the funds managed by the Strategy.
+- **Further reading**, see [YIP-51](https://yips.yearn.finance/YIPS/yip-51), [YIP-52](https://yips.yearn.finance/YIPS/yip-52), [YIP-54](https://yips.yearn.finance/YIPS/yip-54), and [YIP-56](https://gov.yearn.finance/t/yip-56-buyback-and-build/8929).
+
 #### Can you explain the 5% fee on additional yield?
 
 - Formerly this was called a "5% fee on subsidized gas" which confused literally everyone except Andre. Technically it is not a performance fee — it's a fee on the some profit-generating transactions that incur high gas costs and are critical to the vault's internal functioning.


### PR DESCRIPTION
Following YIPS 51, 52 and 54 the new fee structure for V2 vaults is different from V1 vaults. Updated the fees section of the FAQ with an entry explaining the new fee structure. 