### PR TITLE
Fix some links

### DIFF
--- a/faq.md
+++ b/faq.md
@@ -61,7 +61,7 @@ But if you think something can be improved, or you found a bug, we want to squas
 #### What are the risks?
 
 - While the assets deposited can't decrease, the debt of the vault can increase. If a strategy does not manage to outperform the debt, then a portion of the asset will be impermanently locked. If a strategy later outperforms the debt again, the asset will again be available to withdraw. There are mechanisms in the vaults to prevent this but nothing is bulletproof.
-- As of now, only _some_ Vaults have been [audited](https://github.com/iearn-finance/yearn-audits/blob/bdb3868c98e4fe2427898db05154942a9192efb1/MixBytes%20-%20Yearn.Finance%20protocol%20v.1%20Smart%20Contracts%20Audit%20Security%20Audit%20Report.pdf).
+- As of now, only _some_ Vaults have been [audited](https://github.com/iearn-finance/yearn-security/tree/master/audits).
 - Smart contract risk with any contracts that the vaults interact with.
 
 #### What are the different yVaults?
@@ -82,7 +82,7 @@ But if you think something can be improved, or you found a bug, we want to squas
 
 **Other Vaults**
 
-- v1 Money Market vaults, formerly called iEarn, can be found [here](https://yearn.finance/earn).
+- v1 Money Market vaults, formerly called iEarn, can be found [here](https://v1.yearn.finance/earn).
 - Additional vaults can be found [here](https://yearn.finance/vaults).
 
 #### If the current strategy for the yCRV vault is farming CRV does it just get added to my balance when I withdrawal?
@@ -172,7 +172,7 @@ But if you think something can be improved, or you found a bug, we want to squas
 
 ### Earn
 
-- [yearn.finance/earn](https://yearn.finance/earn)
+- [yearn.finance/earn](https://v1.yearn.finance/earn)
 
 #### What is Earn?
 

--- a/products/earn.md
+++ b/products/earn.md
@@ -14,4 +14,4 @@ As of September 2020, the YTD annualized return for yPool liquidity providers is
 
 ## Resources
 
-- [Earn Homepage](https://yearn.finance/earn)
+- [Earn Homepage](https://v1.yearn.finance/earn)

--- a/yusd.md
+++ b/yusd.md
@@ -48,6 +48,6 @@ At this tier the current strategy sits on top of the lower two tiers and **harve
   - yUSD Token contract: [0x5dbcF33D8c2E976c6b560249878e6F1491Bca25c](https://etherscan.io/address/0x5dbcF33D8c2E976c6b560249878e6F1491Bca25c)
 - Code
   - The vaults.finance source code on [GitHub](https://github.com/banteg/yearn-recycle)
-  - The current strategy: [StrategyCurveYCRVVoter](https://etherscan.io/address/0xc999fb87AcA383A63D804A575396F65A55aa5aC8#code)
+  - The current strategy: [StrategyCurveYVoterProxy](https://etherscan.io/address/0x07db4b9b3951094b9e278d336adf46a036295de7#code)
 - FAQ
   - [https://docs.yearn.finance/faq\#vaults](https://docs.yearn.finance/faq#vaults)


### PR DESCRIPTION
Update iEarn links to point to https://v1.yearn.finance/earn, update audits github repo and yUSD strategy contract.