### PR TITLE
updating linter to fix instead of check

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -34,7 +34,7 @@ jobs:
         run: npm install
 
       - name: Run linter on
-        run: npm run lint:check
+        run: npm run lint:fix
 
       - name: Check markdown links
         uses: gaurav-nelson/github-action-markdown-link-check@v1


### PR DESCRIPTION
I'm trying to fix our linter issue. I'm not an expert, but if we run on pull request a linter:fix instead of linter:check this would fix all the '*' and '-' issues potentially.

A normal User flow would be:

1. Fork yearn-docs repo or pull form yearn-docs/master to my-repo/master to get the latest updates.
2. Create a gitbook and fetch from my-repo/master
3. Edit on gitbook interface anything that I need.
4. Merge my gitbook changes through gitbook UI to my REPO.
5. Check on my gitbook if everything looks fine.
6. Go to my-repo and create a PR, submit PR.
7. On PR the year-docs/ repo executes "npm run lint:fix" which changes all the '*' and '-'.
8. Linter step passes.
9. yearn-docs/ repo owner merges to master successfully.
10. Yearn Gitbook Owner validates on LIVE that changes are correct.
